### PR TITLE
Include D:\Games to SearchHearthstoneDirectory candidates

### DIFF
--- a/src/Hearthrock.Client/Hacking/PatchHelper.cs
+++ b/src/Hearthrock.Client/Hacking/PatchHelper.cs
@@ -169,7 +169,7 @@ namespace Hearthrock.Client.Hacking
         /// <returns>The hearthstone directory</returns>
         private static string SearchHearthstoneDirectory()
         {
-            var candicates = new string[] { string.Empty, @"C:\Program Files\", @"C:\Program Files (x86)\", @"C:\Games\" };
+            var candicates = new string[] { string.Empty, @"C:\Program Files\", @"C:\Program Files (x86)\", @"C:\Games\", @"D:\Games\" };
 
             foreach (var candicate in candicates)
             {


### PR DESCRIPTION
I am getting the error Cannot find Hearthstone Directory because my HS folder is located in D:\Games